### PR TITLE
Add set track user steps and for ios disable swizzling

### DIFF
--- a/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
+++ b/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
@@ -1003,7 +1003,7 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
      * @param isEnabled isEnabled flag
      */
     public void setTrackUserSteps(boolean isEnabled) {
-        if isEnabled {
+        if (isEnabled) {
             Instabug.setTrackingUserStepsState(Feature.State.ENABLED);
         } else {
             Instabug.setTrackingUserStepsState(Feature.State.DISABLED);

--- a/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
+++ b/android/src/main/java/com/instabug/instabugflutter/InstabugFlutterPlugin.java
@@ -997,4 +997,16 @@ public class InstabugFlutterPlugin implements MethodCallHandler {
         Instabug.disable();
     }
 
+    /**
+     * Sets tracking of usersteps.
+     *
+     * @param isEnabled isEnabled flag
+     */
+    public void setTrackUserSteps(boolean isEnabled) {
+        if isEnabled {
+            Instabug.setTrackingUserStepsState(Feature.State.ENABLED);
+        } else {
+            Instabug.setTrackingUserStepsState(Feature.State.DISABLED);
+        }
+    }
 }

--- a/ios/Classes/InstabugFlutterPlugin.h
+++ b/ios/Classes/InstabugFlutterPlugin.h
@@ -424,4 +424,17 @@
 
 + (void)networkLog:(NSDictionary *)networkData;
 
+/**
+  * By default, user steps are collected by the SDK. These are all the steps the user has done up to the latest report. This feature can be disabled using this API
+  *
+  * @param isEnabled boolean
+  */
++ (void)setTrackUserSteps:(NSNumber *)isEnabled;
+
+/**
+  * Available on iOS only 
+  * Disables method swizzling for Instabug
+  */
++ (void)disableMethodSwizzling;
+
 @end

--- a/ios/Classes/InstabugFlutterPlugin.m
+++ b/ios/Classes/InstabugFlutterPlugin.m
@@ -827,6 +827,24 @@ FlutterMethodChannel* channel;
     [Instabug setReproStepsMode:reproMode];
 }
 
+/**
+  * These are all the steps the user has done up to the latest report. This feature can be disabled using this API
+  * 
+  * @param isEnabled {boolean} isEnabled
+  */
++ (void)setTrackUserSteps:(NSNumber *)isEnabled {
+  BOOL boolValue = [isEnabled boolValue];
+  Instabug.trackUserSteps = boolValue;
+}
+
+/**
+  * Disables method swizzling for Instabug.
+  */
++ (void)disableMethodSwizzling {
+  [Instabug disableMethodSwizzling];
+}
+
+
 + (NSDictionary *)constants {
   return @{
       @"InvocationEvent.shake": @(IBGInvocationEventShake),

--- a/lib/Instabug.dart
+++ b/lib/Instabug.dart
@@ -293,6 +293,22 @@ class Instabug {
     await _channel.invokeMethod<Object>('setReproStepsMode:', params);
   }
 
+  /// Enables trackUserSteps.
+  /// Default is true.
+  /// [isEnabled] isEnabled value
+  static Future<void> setTrackUserSteps(bool isEnabled) async {
+    final List<dynamic> params = <dynamic>[isEnabled];
+    await _channel.invokeMethod<Object>('setTrackUserSteps:', params);
+  }
+
+  /// iOS only
+  /// Disable method swizzling
+  static Future<void> disableMethodSwizzling() async {
+    if (Platform.isIOS) {
+      await _channel.invokeMethod<Object>('disableMethodSwizzling:');
+    }
+  }
+
   ///Android Only
   ///Enables all Instabug functionality
   static Future<void> enableAndroid() async {

--- a/test/instabug_flutter_test.dart
+++ b/test/instabug_flutter_test.dart
@@ -707,6 +707,18 @@ void main() {
     ]);
   });
 
+  test('setTrackUserSteps: Test', () async {
+    const isEnabled = false;
+    final List<dynamic> args = <dynamic>[isEnabled];
+    Instabug.setTrackUserSteps(isEnabled);
+    expect(log, <Matcher>[
+      isMethodCall(
+        'setTrackUserSteps:',
+        arguments: args,
+      )
+    ]);
+  });
+
   test('sendJSCrashByReflection:handled: Test', () async {
     try {
       final List<dynamic> params = <dynamic>[1, 2];
@@ -734,6 +746,18 @@ void main() {
       ]);
     }
   });
+
+  ///Since the below method only runs on iOS and has the [Platform.isIOS] condition in it, it will fail when running outside iOS,
+  /// therefore its commented.
+  // test('disableMethodSwizzling: Test', () async {
+  //   Instabug.disableMethodSwizzling();
+  //   expect(log, <Matcher>[
+  //     isMethodCall(
+  //       'disableMethodSwizzling:',
+  //       arguments: null,
+  //     )
+  //   ]);
+  // });
 
   ///Since the below method only runs on android and has the [Platform.isAndroid] condition in it, it will fail when running outside android,
   /// therefore its commented.


### PR DESCRIPTION
## Summary of Changes

+ add `setTrackUserSteps`

iOS Only
+ add `disableMethodSwizzling`

<!-- For pull requests that add new APIs, please make sure to go through this checklist. 
For other types of pull requests, please remove it.-->
## Checklist
- [x] In addition to adding the new API to Dart, I have also added its implementation to both iOS and Android.
- [x] I have added at least 1 unit test in Dart for the new API and made sure the tests pass locally.
- [ ] I have updated [README.md](https://github.com/Instabug/Instabug-Flutter/blob/master/README.md) to add the new API.
